### PR TITLE
Added support to parse string variables with spaces

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ function parseEnvString(data, {
   delimiter = ['$', '']
 } = {}){
   var resultEnvMap = {};
-  const EXTRACT_ENV_NAME_AND_VALUE_REGEX = /^([^= ]+)=(\S+)/gm;
+  const EXTRACT_ENV_NAME_AND_VALUE_REGEX = /^([^= ]+)=([^\n]*)/gm;
   var results;
   while ((results = EXTRACT_ENV_NAME_AND_VALUE_REGEX.exec(data)) !== null) {
     let variableName = results[1].trim();


### PR DESCRIPTION
I had an issue parsing env variables which content was strings with many spaces.
```NAME=project name with space```
I retrieved:
```'NAME': 'project'```
So the regex was modified to match everything after the equal (=) til the break line.

All test cases implemented passed successful.